### PR TITLE
Give the entity log cap a single source of truth

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2022 Daniel McCoy Stephenson
 # Apache License 2.0
+from entity.livingEntity import DEFAULT_LOG_MAX_SIZE
 
 
 # @author Daniel McCoy Stephenson
@@ -21,7 +22,10 @@ class Config:
         self.maxEntitiesLimit = 200  # Hard upper limit for entities
         self.entityCullThreshold = 0.9  # Cull entities when population reaches 90% of max
         self.entityCullTarget = 0.7  # Reduce population to 70% of max when culling
-        self.entityLogMaxSize = 50  # Maximum number of log entries per entity to prevent memory bloat
+        # Maximum number of log entries per entity to prevent memory bloat. The
+        # default is taken from the entity module so the cap has one definition;
+        # every entity is constructed with whatever this is set to.
+        self.entityLogMaxSize = DEFAULT_LOG_MAX_SIZE
         
         # Dynamic performance monitoring settings
         self.lagThreshold = 0.05  # Tick time in seconds that indicates lag (50ms)

--- a/src/entity/livingEntity.py
+++ b/src/entity/livingEntity.py
@@ -5,17 +5,23 @@ from collections import deque
 from flags.flags import Flags
 from stats.stats import Stats
 
+# The single source of truth for how many log entries an entity retains.
+# Config.entityLogMaxSize reads this value rather than redeclaring it, so the
+# cap cannot drift between the two.
+DEFAULT_LOG_MAX_SIZE = 50
+
 
 # @author Daniel McCoy Stephenson
 # @since 2017
 class LivingEntity(object):
-    def __init__(self, name):
+    def __init__(self, name, maxLogSize=DEFAULT_LOG_MAX_SIZE):
         self.name = name
         self.chanceToFight = random.randint(45, 55)  # Back to normal values
         self.chanceToBefriend = 100 - self.chanceToFight
         self.health = random.randint(80, 120)  # Health between 80-120
         self.maxHealth = self.health  # Track maximum health for potential future use
-        self.log = ["%s was created." % self.name]
+        self.maxLogSize = maxLogSize
+        self.log = deque(["%s was created." % self.name], maxlen=maxLogSize)
         self.friends = []
         self.stats = Stats()
         self.flags = Flags()
@@ -165,15 +171,13 @@ class LivingEntity(object):
                     % (self.name, regeneration, self.health, self.maxHealth)
                 )
 
-    def addLogEntry(self, message, maxLogSize=50):
-        """Add a log entry and maintain log size limit.
+    def addLogEntry(self, message):
+        """Add a log entry, dropping the oldest once the entity's cap is hit.
 
-        Backed by a deque bounded to maxLogSize so repeated appends are O(1)
-        instead of copying up to maxLogSize elements on every call once the
-        cap is reached (this fires on nearly every action, every tick, for
-        every entity, so it's on the hot path this feature exists to keep
-        cheap).
+        The cap belongs to the entity and is fixed at construction time, so
+        this is a bare O(1) append onto an already-bounded deque. Taking the
+        cap per call instead would let callers disagree about it and force the
+        deque to be rebuilt — an O(n) copy on a path that runs for every
+        entity on every action on every tick.
         """
-        if not isinstance(self.log, deque) or self.log.maxlen != maxLogSize:
-            self.log = deque(self.log, maxlen=maxLogSize)
         self.log.append(message)

--- a/src/entity/livingEntity.py
+++ b/src/entity/livingEntity.py
@@ -20,7 +20,8 @@ class LivingEntity(object):
         self.chanceToBefriend = 100 - self.chanceToFight
         self.health = random.randint(80, 120)  # Health between 80-120
         self.maxHealth = self.health  # Track maximum health for potential future use
-        self.maxLogSize = maxLogSize
+        # The deque's maxlen is the cap; storing it separately would recreate
+        # the very duplication this parameter exists to remove.
         self.log = deque(["%s was created." % self.name], maxlen=maxLogSize)
         self.friends = []
         self.stats = Stats()

--- a/src/kreatures.py
+++ b/src/kreatures.py
@@ -12,15 +12,19 @@ from config.config import Config
 # @author Daniel McCoy Stephenson
 class Kreatures:
     def __init__(self):
-        self.environment = World()
+        # Config comes first: every entity created from here on is given the
+        # configured log cap, so the setting applies to the whole world.
+        self.config = Config()
+        self.environment = World(self.config.entityLogMaxSize)
         self.names = self._load_names()
 
         print("What would you like to name your kreature?")
         self.creatureName = input("> ")
-        self.playerCreature = LivingEntity(self.creatureName)
+        self.playerCreature = LivingEntity(
+            self.creatureName, self.config.entityLogMaxSize
+        )
 
         self.running = True
-        self.config = Config()
         self.tick = 0
         
         # Performance monitoring for dynamic entity limits
@@ -150,7 +154,10 @@ class Kreatures:
     def createEntity(self):
         if not self.canCreateNewEntity():
             return None
-        newEntity = LivingEntity(self.names[random.randint(0, len(self.names) - 1)])
+        newEntity = LivingEntity(
+            self.names[random.randint(0, len(self.names) - 1)],
+            self.config.entityLogMaxSize,
+        )
         self.environment.addEntity(newEntity)
         return newEntity
 
@@ -163,7 +170,7 @@ class Kreatures:
             return None
             
         childName = self.names[random.randint(0, len(self.names) - 1)]
-        child = LivingEntity(childName)
+        child = LivingEntity(childName, self.config.entityLogMaxSize)
 
         # Set up parent-child relationships
         child.addParent(parent1)
@@ -181,8 +188,7 @@ class Kreatures:
         child.maxHealth = child.health
 
         child.addLogEntry(
-            "%s is the child of %s and %s." % (childName, parent1.name, parent2.name),
-            self.config.entityLogMaxSize
+            "%s is the child of %s and %s." % (childName, parent1.name, parent2.name)
         )
 
         self.environment.addEntity(child)

--- a/src/stats/__init__ copy.py
+++ b/src/stats/__init__ copy.py
@@ -1,2 +1,0 @@
-# Copyright (c) 2022 Daniel McCoy Stephenson
-# Apache License 2.0

--- a/src/world/world.py
+++ b/src/world/world.py
@@ -9,7 +9,6 @@ import random
 class World(object):
     def __init__(self, maxLogSize=DEFAULT_LOG_MAX_SIZE):
         self.entities = []
-        self.maxLogSize = maxLogSize
 
         # create ten creatures for the world to have to start with
         self.Alison = LivingEntity("Alison", maxLogSize)

--- a/src/world/world.py
+++ b/src/world/world.py
@@ -1,26 +1,27 @@
 # Copyright (c) 2022 Daniel McCoy Stephenson
 # Apache License 2.0
-from entity.livingEntity import LivingEntity
+from entity.livingEntity import LivingEntity, DEFAULT_LOG_MAX_SIZE
 import random
 
 
 # @author Daniel McCoy Stephenson
 # @since 2017
 class World(object):
-    def __init__(self):
+    def __init__(self, maxLogSize=DEFAULT_LOG_MAX_SIZE):
         self.entities = []
+        self.maxLogSize = maxLogSize
 
         # create ten creatures for the world to have to start with
-        self.Alison = LivingEntity("Alison")
-        self.Barry = LivingEntity("Barry")
-        self.Conrad = LivingEntity("Conrad")
-        self.Derrick = LivingEntity("Derrick")
-        self.Eric = LivingEntity("Eric")
-        self.Francis = LivingEntity("Francis")
-        self.Gary = LivingEntity("Gary")
-        self.Harry = LivingEntity("Harry")
-        self.Isabelle = LivingEntity("Isabelle")
-        self.Jasper = LivingEntity("Jasper")
+        self.Alison = LivingEntity("Alison", maxLogSize)
+        self.Barry = LivingEntity("Barry", maxLogSize)
+        self.Conrad = LivingEntity("Conrad", maxLogSize)
+        self.Derrick = LivingEntity("Derrick", maxLogSize)
+        self.Eric = LivingEntity("Eric", maxLogSize)
+        self.Francis = LivingEntity("Francis", maxLogSize)
+        self.Gary = LivingEntity("Gary", maxLogSize)
+        self.Harry = LivingEntity("Harry", maxLogSize)
+        self.Isabelle = LivingEntity("Isabelle", maxLogSize)
+        self.Jasper = LivingEntity("Jasper", maxLogSize)
 
         self.starterEntities = [
             self.Alison,

--- a/tests/test_lag_prevention.py
+++ b/tests/test_lag_prevention.py
@@ -26,12 +26,12 @@ class TestPopulationControl:
 
     def test_entity_log_size_management(self):
         """Test that entity logs are kept within size limits"""
-        entity = LivingEntity("TestEntity")
-        
+        entity = LivingEntity("TestEntity", maxLogSize=10)
+
         # Add many log entries
         for i in range(100):
-            entity.addLogEntry(f"Log entry {i}", maxLogSize=10)
-        
+            entity.addLogEntry(f"Log entry {i}")
+
         # Should only keep the most recent 10 entries
         assert len(entity.log) == 10
         assert "Log entry 99" in entity.log[-1]
@@ -174,14 +174,48 @@ class TestPerformanceOptimizations:
     def test_entity_addlogentry_uses_config_limit(self):
         """Test that addLogEntry respects the configured log size limit"""
         config = Config()
-        entity = LivingEntity("TestEntity")
-        
+        entity = LivingEntity("TestEntity", config.entityLogMaxSize)
+
         # Add more entries than the config limit
         for i in range(config.entityLogMaxSize + 20):
-            entity.addLogEntry(f"Entry {i}", maxLogSize=config.entityLogMaxSize)
-        
+            entity.addLogEntry(f"Entry {i}")
+
         # Should not exceed the configured limit
         assert len(entity.log) <= config.entityLogMaxSize
+
+    def test_config_log_cap_is_the_only_source_of_truth(self):
+        """A non-default entityLogMaxSize must reach every entity the game creates.
+
+        The cap was previously declared twice — as a default parameter on
+        addLogEntry and as a Config field — so changing the config value left
+        most callers on the old default. A cap that is not 50 catches that:
+        with two sources of truth, entities built without the config value
+        keep the stale default.
+        """
+        from kreatures import Kreatures
+
+        customConfig = Config()
+        customConfig.entityLogMaxSize = 7
+
+        with patch('kreatures.Config', return_value=customConfig):
+            with patch('builtins.input', return_value='TestPlayer'):
+                with patch('builtins.print'):
+                    game = Kreatures()
+
+                    parent1, parent2 = game.environment.getEntities()[:2]
+                    game.createEntity()
+                    game.createChildEntity(parent1, parent2)
+
+        # Player, starter creatures, spawned creatures and children alike
+        assert game.playerCreature.log.maxlen == 7
+        for entity in game.environment.getEntities():
+            assert entity.log.maxlen == 7
+
+        # And the cap is actually enforced, not merely recorded
+        for i in range(20):
+            game.playerCreature.addLogEntry("Entry %d" % i)
+        assert len(game.playerCreature.log) == 7
+        assert "Entry 19" in game.playerCreature.log[-1]
 
     def test_empty_entity_list_handling(self):
         """Test that empty entity lists are handled gracefully"""


### PR DESCRIPTION
## Summary

- The per-entity log cap was declared in two places: as a default parameter on `LivingEntity.addLogEntry` (`maxLogSize=50`) and as `Config.entityLogMaxSize`. Of every call site, only `Kreatures.createChildEntity` passed the configured value, so the setting was effectively inert and the two values would have diverged the moment either was changed.
- The cap is now owned by the entity and fixed at construction: `LivingEntity(name, maxLogSize=DEFAULT_LOG_MAX_SIZE)` builds `self.log` as an already-bounded `deque`, and `addLogEntry(message)` is a bare O(1) append with no cap argument. The `isinstance`/`maxlen` check that would have rebuilt the deque on nearly every call has been dropped, since divergence is no longer possible.
- `DEFAULT_LOG_MAX_SIZE` is defined once, in `src/entity/livingEntity.py`, and `Config.entityLogMaxSize` is initialised from it. This adds one import from `config` to `entity`; it is what makes "one source of truth" literally true rather than two literals that happen to agree.
- The configured cap is now propagated to *every* entity the game creates — the world's ten starter creatures (`World.__init__` takes `maxLogSize`), the player creature, creatures spawned by `createEntity`, and children from `createChildEntity`. `Config` is constructed first in `Kreatures.__init__` so the world can be given the value.
- The stray `src/stats/__init__ copy.py` has been deleted. It was byte-identical to `src/stats/__init__.py`, is not importable (the space makes the name invalid as a module identifier), and is referenced by nothing.

## Test plan

- [x] `python3 -m pytest --verbose -vv --cov=src --cov-report=term-missing` — 66 passed (65 before; one test added).
- [x] `python3 -m compileall -q src` — clean.
- [x] `tests/test_lag_prevention.py::TestPerformanceOptimizations::test_config_log_cap_is_the_only_source_of_truth` was added as the regression guard: a `Config` with `entityLogMaxSize = 7` is injected into `Kreatures`, and every entity — player, starters, spawned, child — is asserted to carry `log.maxlen == 7`, with enforcement checked by overflowing the log. This test fails against the previous code, where entities built without the config value kept the stale default of 50.
- [x] The two existing tests that passed a per-call `maxLogSize` were updated to set the cap at construction instead; their assertions were kept intact rather than weakened.
- [x] A 60-tick end-to-end play-through of `src/kreatures.py` was run locally with mocked input; the simulation completed and printed its summary, confirming that `log` being a `deque` from construction is compatible with the `log[0]` / `del log[0]` handling in `Kreatures.run`.

## Deferred this cycle

The remaining open issues were not picked up, for these reasons:

- #36 and #38 — already assigned to Copilot, and #38 ("Optimize simulation code") is far larger than a single-cycle scope.
- #41 — `COPYRIGHT.md` is on this project's do-not-auto-merge list, so it needs explicit human sign-off rather than an autonomous cycle.
- #42 — `.github/copilot-instructions.md` is agent-loaded configuration and requires separate explicit authorization before being edited.

## Notes

Pre-existing `black` drift in the touched files (single-quoted strings, trailing whitespace on blank lines) was deliberately left alone so that this diff stays scoped to the two issues; it belongs in its own formatting-only sweep.

Closes #40
Closes #43

<!-- gardener-tend-dispatch -->

_This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener)._